### PR TITLE
Changed how BusConfig gets the manager address

### DIFF
--- a/client/comm.py
+++ b/client/comm.py
@@ -9,7 +9,7 @@ import os
 from multiprocessing.managers import BaseManager
 from abc import abstractmethod, ABC
 
-from common.common import Frame, Priority, BusConfig, FrameWrapper
+from common.common import Frame, Priority, BUSCONFIG, FrameWrapper
 from common.frame_enum import FrameType
 
 
@@ -92,7 +92,7 @@ QueueManager.register('tx_queue')
 
 class Comm(BaseComm):
     def __init__(self):
-        self.manager = QueueManager(address=BusConfig.ADDRESS, authkey=BusConfig.AUTH_KEY)
+        self.manager = QueueManager(address=BUSCONFIG.ADDRESS.tuple(), authkey=BUSCONFIG.AUTH_KEY)
         self.manager.connect()
 
         # Queues that refer to the bus process

--- a/common/common.py
+++ b/common/common.py
@@ -3,12 +3,21 @@ this module contains configuration and base Frame definitions
 """
 import struct
 from enum import Enum
+import os
 
 class BusConfig:
     "this class contains the configuration options for the bus"
     AUTH_KEY = b'r2d2'
     PORT = 5000
-    ADDRESS = ('127.0.0.1', PORT)
+    if os.environ.get('AM_I_IN_A_DOCKER_CONTAINER', False):
+        try:
+            remote_ip = socket.gethostbyname( 'server_manager' )
+        except socket.gaierror:
+            print('Hostname could not be resolved. Falling back to default')
+            remote_ip = '172.18.0.2'
+        ADDRESS = (remote_ip, PORT)
+    else:
+        ADDRESS = ('127.0.0.1', PORT)
 
 
 class AutoNumber(Enum):

--- a/manager/manager.py
+++ b/manager/manager.py
@@ -13,7 +13,7 @@ import signal
 from time import sleep
 from multiprocessing.managers import BaseManager
 from multiprocessing import Lock
-from common.common import BusConfig
+from common.common import BUSCONFIG
 
 
 class QueueManager(BaseManager):
@@ -76,7 +76,7 @@ class BusManager:
         QueueManager.register('rx_queue', callable=lambda: self.rx_queue)
         # Register the queue for sending frames to modules
         QueueManager.register('tx_queue', callable=lambda: self.tx_queue)
-        self.manager = QueueManager(address=('', BusConfig.PORT), authkey=BusConfig.AUTH_KEY)
+        self.manager = QueueManager(address=('', BUSCONFIG.ADDRESS.port), authkey=BUSCONFIG.AUTH_KEY)
         self.server = self.manager.get_server()
 
         print("Start serving!")
@@ -142,7 +142,7 @@ class BusManager:
 
         print("Starting consumer...")
 
-        pusher = QueueManager(address=BusConfig.ADDRESS, authkey=BusConfig.AUTH_KEY)
+        pusher = QueueManager(address=BUSCONFIG.ADDRESS.tuple(), authkey=BUSCONFIG.AUTH_KEY)
         pusher.connect()
 
         print("Init done, working...")


### PR DESCRIPTION
BusConfig now detects whether or not it is running within docker.

If it is, it'll try to get the server-manager's address by it's hostname, should it fail, it'll fall back to the supposedly static IP although it isn't fully guaranteed to be static.

If it isn't within a docker container, nothing's changed and it'll try to connect to localhost